### PR TITLE
Better thread assignment

### DIFF
--- a/Exchange/test/test_event_parser.cpp
+++ b/Exchange/test/test_event_parser.cpp
@@ -23,10 +23,11 @@ TEST_F(EventParserTest, ParseNewOrder_ValidMarketOrder) {
     std::string csv = "D,user123,1001,AAPL,100,BUY,MARKET";
     
     auto event = parser->parse(csv);
-    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
+
+    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
+    EXPECT_EQ(event.symbol(), "AAPL"_sym);
 
     EXPECT_EQ(newOrderEvent.eventType(), EventType::NewOrder);
-
     EXPECT_EQ(newOrderEvent.userId_, UserIdType("user123"));
     EXPECT_EQ(newOrderEvent.clientOrderId_, 1001);
     EXPECT_EQ(newOrderEvent.symbol_, "AAPL"_sym);
@@ -41,7 +42,9 @@ TEST_F(EventParserTest, ParseNewOrder_ValidLimitOrder) {
     std::string csv = "D,user456,1002,MSFT,50,SELL,LIMIT,150.75";
     
     auto event = parser->parse(csv);
-    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
+
+    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
+    EXPECT_EQ(event.symbol(), "MSFT"_sym);
 
     EXPECT_EQ(newOrderEvent.eventType(), EventType::NewOrder);
     EXPECT_EQ(newOrderEvent.userId_, UserIdType("user456"));
@@ -57,7 +60,9 @@ TEST_F(EventParserTest, ParseNewOrder_WithWhitespace) {
     std::string csv = " D , user789 , 1003 , GOOGL , 200 , BUY , MARKET ";
     
     auto event = parser->parse(csv);
-    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
+
+    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
+    EXPECT_EQ(event.symbol(), "GOOGL"_sym);
     
     EXPECT_EQ(newOrderEvent.eventType(), EventType::NewOrder);
     
@@ -69,12 +74,15 @@ TEST_F(EventParserTest, ParseNewOrder_WithWhitespace) {
     EXPECT_EQ(newOrderEvent.type_, Type::Market);
 }
 
+
 TEST_F(EventParserTest, ParseNewOrder_CaseInsensitive) {
     std::string csv = "d,user101,1004,TSLA,75,sell,limit,250.50";
     
     auto event = parser->parse(csv);
+    EXPECT_EQ(event.symbol(), "TSLA"_sym);
+
     
-    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
+    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
     
     EXPECT_EQ(newOrderEvent.eventType(), EventType::NewOrder);
     EXPECT_EQ(newOrderEvent.userId_, UserIdType("user101"));
@@ -90,9 +98,11 @@ TEST_F(EventParserTest, ParseNewOrder_ShortForm) {
     std::string csv = "D,user202,1005,NFLX,25,1,2,180.25";
     
     auto event = parser->parse(csv);
+
     
-    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
-    
+    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
+    EXPECT_EQ(event.symbol(), "NFLX"_sym);
+
     EXPECT_EQ(newOrderEvent.eventType(), EventType::NewOrder);
     EXPECT_EQ(newOrderEvent.userId_, UserIdType("user202"));
     EXPECT_EQ(newOrderEvent.clientOrderId_, 1005);
@@ -155,8 +165,9 @@ TEST_F(EventParserTest, ParseNewOrder_ZeroQuantity) {
     std::string csv = "D,user1111,1013,ADBE,0,BUY,MARKET";
     
     auto event = parser->parse(csv);
+    EXPECT_EQ(event.symbol(), "ADBE"_sym);
     
-    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
+    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
     
     EXPECT_EQ(newOrderEvent.eventType(), EventType::NewOrder);
     EXPECT_EQ(newOrderEvent.quantity_, 0);
@@ -166,8 +177,9 @@ TEST_F(EventParserTest, ParseNewOrder_LargeNumbers) {
     std::string csv = "D,user1212,999999,UBER,1000000,SELL,LIMIT,999999.99";
     
     auto event = parser->parse(csv);
+    EXPECT_EQ(event.symbol(), "UBER"_sym);
     
-    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
+    NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
     
     EXPECT_EQ(newOrderEvent.eventType(), EventType::NewOrder);
     EXPECT_EQ(newOrderEvent.clientOrderId_, 999999);
@@ -187,8 +199,9 @@ TEST_F(EventParserTest, ParseCancelOrder_Valid) {
     std::string csv = "F,user123,1001,AAPL,2001";
     
     auto event = parser->parse(csv);
+    EXPECT_EQ(event.symbol(), "AAPL"_sym);
     
-    CancelOrderEvent cancelOrderEvent = std::get<CancelOrderEvent>(event);
+    CancelOrderEvent cancelOrderEvent = std::get<CancelOrderEvent>(event.data_);
     
     EXPECT_EQ(cancelOrderEvent.eventType(), EventType::CancelOrder);
     EXPECT_EQ(cancelOrderEvent.userId_, UserIdType("user123"));
@@ -200,8 +213,9 @@ TEST_F(EventParserTest, ParseCancelOrder_WithWhitespace) {
     std::string csv = " F , user456 , 1002 , MSFT , 2002 ";
     
     auto event = parser->parse(csv);
+    EXPECT_EQ(event.symbol(), "MSFT"_sym);
     
-    CancelOrderEvent cancelOrderEvent = std::get<CancelOrderEvent>(event);
+    CancelOrderEvent cancelOrderEvent = std::get<CancelOrderEvent>(event.data_);
     
     EXPECT_EQ(cancelOrderEvent.eventType(), EventType::CancelOrder);
     EXPECT_EQ(cancelOrderEvent.userId_, UserIdType("user456"));
@@ -227,8 +241,9 @@ TEST_F(EventParserTest, ParseTopOfBook_Valid) {
     std::string csv = "V,user123,1001,AAPL";
     
     auto event = parser->parse(csv);
+    EXPECT_EQ(event.symbol(), "AAPL"_sym);
     
-    TopOfBookEvent topOfBookEvent = std::get<TopOfBookEvent>(event);
+    TopOfBookEvent topOfBookEvent = std::get<TopOfBookEvent>(event.data_);
     
     EXPECT_EQ(topOfBookEvent.eventType(), EventType::TopOfBook);
     EXPECT_EQ(topOfBookEvent.userId_, UserIdType("user123"));
@@ -239,8 +254,9 @@ TEST_F(EventParserTest, ParseTopOfBook_WithWhitespace) {
     std::string csv = " V , user456 , 1002 , MSFT ";
     
     auto event = parser->parse(csv);
+    EXPECT_EQ(event.symbol(), "MSFT"_sym);
     
-    TopOfBookEvent topOfBookEvent = std::get<TopOfBookEvent>(event);
+    TopOfBookEvent topOfBookEvent = std::get<TopOfBookEvent>(event.data_);
     
     EXPECT_EQ(topOfBookEvent.eventType(), EventType::TopOfBook);
     EXPECT_EQ(topOfBookEvent.userId_, UserIdType("user456"));
@@ -258,7 +274,7 @@ TEST_F(EventParserTest, ParseTopOfBook_TooFewTokens) {
 TEST_F(EventParserTest, ParseQuit_Valid) {
     std::string csv = "Q";
     
-    auto event = parser->parse(csv);
+    auto event = parser->parse(csv).data_;
     
     QuitEvent quitEvent = std::get<QuitEvent>(event);
     EXPECT_EQ(quitEvent.eventType(), EventType::Quit);
@@ -267,7 +283,7 @@ TEST_F(EventParserTest, ParseQuit_Valid) {
 TEST_F(EventParserTest, ParseQuit_WithWhitespace) {
     std::string csv = " Quit ";
     
-    auto event = parser->parse(csv);
+    auto event = parser->parse(csv).data_;
     
     QuitEvent quitEvent = std::get<QuitEvent>(event);
     EXPECT_EQ(quitEvent.eventType(), EventType::Quit);
@@ -292,7 +308,8 @@ TEST_F(EventParserTest, CreateNewOrderEvent_VariousRanges) {
    std::list<std::string> tokens = {"D", "user456", "1002", "MSFT", "50", "SELL", "LIMIT", "150.75"};
     
     auto verify = [](const auto& event) {
-      NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event);
+      EXPECT_EQ(event.symbol(), "MSFT"_sym);
+      NewOrderEvent newOrderEvent = std::get<NewOrderEvent>(event.data_);
       EXPECT_EQ(newOrderEvent.userId_, UserIdType("user456"));  
       EXPECT_EQ(newOrderEvent.clientOrderId_, 1002);
       EXPECT_EQ(newOrderEvent.symbol_, "MSFT"_sym);
@@ -324,7 +341,8 @@ TEST_F(EventParserTest, CreateCancelOrderEvent_VariousRanges) {
   std::list<std::string> tokens {"F", "user123", "1001", "AAPL", "2001"};
 
     auto verify = [](const auto& event) {
-      CancelOrderEvent cancelOrderEvent = std::get<CancelOrderEvent>(event);
+      EXPECT_EQ(event.symbol(), "AAPL"_sym);
+      CancelOrderEvent cancelOrderEvent = std::get<CancelOrderEvent>(event.data_);
       EXPECT_EQ(cancelOrderEvent.userId_, UserIdType("user123"));
       EXPECT_EQ(cancelOrderEvent.clientOrderId_, 1001);
       EXPECT_EQ(cancelOrderEvent.symbol_, "AAPL"_sym);
@@ -354,7 +372,8 @@ TEST_F(EventParserTest, CreateTopOfBookEvent_VariousRanges) {
   std::list<std::string> tokens {"V", "user456", "1002", "MSFT"};
 
   auto verify = [](const auto& event) {
-    TopOfBookEvent topOfBookEvent = std::get<TopOfBookEvent>(event);
+    EXPECT_EQ(event.symbol(), "MSFT"_sym);
+    TopOfBookEvent topOfBookEvent = std::get<TopOfBookEvent>(event.data_);
     EXPECT_EQ(topOfBookEvent.userId_, UserIdType("user456"));
     EXPECT_EQ(topOfBookEvent.clientOrderId_, 1002);
     EXPECT_EQ(topOfBookEvent.symbol_, "MSFT"_sym );
@@ -381,7 +400,7 @@ TEST_F(EventParserTest, CreateQuitEvent_VariousRanges) {
   std::list<std::string> tokens {"Q"};
 
   auto verify = [](const auto& event) {
-    QuitEvent quitEvent = std::get<QuitEvent>(event);
+    QuitEvent quitEvent = std::get<QuitEvent>(event.data_);
     EXPECT_EQ(quitEvent.eventType(), EventType::Quit);
   };
 


### PR DESCRIPTION
Switching to sharding threads so each OrderBook is always handled by ust one thread.
Execution will be much cleaner (no race on timestamps) and easier to process.

Easier to switch now.